### PR TITLE
Mobile Safari related fixes

### DIFF
--- a/sdks/js/src/classes/sdk.js
+++ b/sdks/js/src/classes/sdk.js
@@ -91,8 +91,10 @@ ZCC.Sdk.init({
       url + 'zcc.outgoingmessage.js'
     ];
 
+    let shouldInitDefaultPlayer = false;
     if (Sdk.initOptions.player && !Utils.isFunction(Sdk.initOptions.player)) {
       scriptsToLoad.push(url + 'zcc.player.js');
+      shouldInitDefaultPlayer = true;
     }
     if (Sdk.initOptions.decoder && !Utils.isFunction(Sdk.initOptions.decoder)) {
       scriptsToLoad.push(url + 'zcc.decoder.js');
@@ -112,9 +114,20 @@ ZCC.Sdk.init({
       if (typeof userCallback === 'function') {
         userCallback.apply(userCallback);
       }
+      if (shouldInitDefaultPlayer) {
+        Sdk.initDefaultPlayer();
+      }
       dfd.resolve();
     });
     return dfd.promise;
+  }
+
+  static initDefaultPlayer() {
+    let library = Utils.getLoadedLibrary();
+    library.IncomingMessage.PersistentPlayer = new library.Player({
+      encoding: '32bitFloat',
+      sampleRate: 48000
+    });
   }
 
   static getMyUrl() {

--- a/sdks/js/webpack.config.js
+++ b/sdks/js/webpack.config.js
@@ -16,14 +16,36 @@ let entryFiles = {
   'OutgoingMessage': './src/classes/outgoingMessage.js'
 };
 
+const NODE_ENV = process.env.NODE_ENV || 'development';
+const IS_NODE_ENV_DEVELOPMENT = NODE_ENV === 'development';
+const IS_NODE_ENV_PRODUCTION = NODE_ENV === 'production';
+
 let renameOutputFiles = {};
 Object.keys(entryFiles).forEach(function(entryPoint) {
   renameOutputFiles[entryPoint] = 'zcc.' + entryPoint.toLowerCase() + '.js';
 });
 
+let plugins = [
+  new renameOutputPlugin(renameOutputFiles)
+];
+
+if (IS_NODE_ENV_PRODUCTION) {
+  plugins.push(
+    new UglifyJsPlugin({
+      uglifyOptions: {
+        output: {
+          comments: false,
+          beautify: false
+        }
+      }
+    })
+  );
+}
+
 module.exports = {
   mode: 'production',
   entry: entryFiles,
+  devtool: IS_NODE_ENV_DEVELOPMENT ? 'source-map' : null,
   output: {
     filename: 'zcc.[name].js',
     library: [settings.libraryName, '[name]'],
@@ -81,15 +103,5 @@ module.exports = {
       }
     ]
   },
-  plugins: [
-    new renameOutputPlugin(renameOutputFiles),
-    new UglifyJsPlugin({
-      uglifyOptions: {
-        output: {
-          comments: false,
-          beautify: false
-        }
-      }
-    })
-  ]
+  plugins: plugins
 };


### PR DESCRIPTION
Problem is that Safari creates AudioContext in the suspended state, so to enable it some user interaction is required.
This initializes default player (which already [has a fix to wait for the first user touch action](https://github.com/zelloptt/pcm-player/commit/571f7a8e8aab72deaec8c5b11b8b37f7e231a2e7)).
This also makes default player persistent between incoming messages and does not destroy the player otherwise initializing the audio context by user interaction would be required for each incoming message.
+ some webpack changes for easier development and debugging