### PR TITLE
Channel config error for widget

### DIFF
--- a/API.md
+++ b/API.md
@@ -181,7 +181,9 @@ Indicates there was a change in channel status, which may include channel being 
 | `command` | string | `on_channel_status`
 | `channel ` | string | The name of the channel
 | `status ` | string | Channel status. Can be `online` or `offline`
-| `users_online ` | integer | Number of users currently connected to the channel. 
+| `users_online ` | integer | Number of users currently connected to the channel.
+| `error` | string | Error details (if channel status was changed to `offline` due to some error). 
+| `channel_config_error` | boolean | Indicates if `offline` status was sent due to channel misconfiguration.
 
 #### Example:
 

--- a/sdks/js/src/classes/widget/index.js
+++ b/sdks/js/src/classes/widget/index.js
@@ -84,7 +84,9 @@ class Widget extends Emitter {
       sending: false,
       muted: true,
       reconnecting: false,
-      wasConnected: false
+      wasConnected: false,
+      channel_config_error: false,
+      error: ''
     };
 
     this.init();
@@ -176,17 +178,6 @@ class Widget extends Emitter {
     DomUtils.removeClass(el, 'zcc-hidden');
   }
 
-  static updateHtml(elem, v, params = null) {
-    if (!elem) {
-      return false;
-    }
-    let str = v;
-    if (typeof v === 'function') {
-      str = v.apply(v, [params]);
-    }
-    elem.innerHTML = str;
-  }
-
   setSession(session) {
     this.session = session;
     this.state.channel = session.options.channel;
@@ -195,6 +186,9 @@ class Widget extends Emitter {
 
     this.session.on(Constants.EVENT_STATUS, (status) => {
       this.state = Object.assign(this.state, status);
+      if (status.error) {
+        this.updateReceivingState(null);
+      }
       this.updateMainHtml();
     });
 

--- a/sdks/js/src/classes/widget/styles/styles.scss
+++ b/sdks/js/src/classes/widget/styles/styles.scss
@@ -74,6 +74,9 @@ $errorColor: darkred;
     @include innerOffset;
     display: block;
     font-size: 12px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   .zcc-live-icon {

--- a/sdks/js/src/classes/widget/styles/styles.scss
+++ b/sdks/js/src/classes/widget/styles/styles.scss
@@ -203,12 +203,14 @@ $errorColor: darkred;
           max-width: 140px;
           overflow: hidden;
           &.zcc-long {
+            position: relative;
             &:after {
               display: inline-flex;
               content: "";
               box-shadow: inset -35px 0px 15px -25px rgba(128,128,128,1);
-              position: fixed;
-              left: 145px;
+              position: absolute;
+              left: 130px;
+              top: 5px;
               width: 10px;
               height: 25px;
               overflow: hidden;

--- a/sdks/js/src/classes/widget/templates/status.ejs
+++ b/sdks/js/src/classes/widget/templates/status.ejs
@@ -1,6 +1,12 @@
 <div class="zcc-status zcc-js">
 <%if (status === 'online') {%><i class="zcc-live-icon">live</i><%= users_online %> users online<%}%>
-<%if (status === 'disconnected' || status === 'offline') {%>Disconnected.<%}%>
+<%if (status === 'disconnected' || status === 'offline') {%>
+    <%if (error && channel_config_error) {%>
+        This channel doesn't support widget. <a href="//zello.com/channel-listen-widget-support">Learn more</a>
+    <%} else {%>
+        Disconnected.
+    <%}%>
+<%}%>
 <%if (status === 'connecting') {%>Connecting...<%}%>
 <%if (status === 'reconnecting') {%>Reconnecting...<%}%>
 <%if (status === 'connect-failed') {%><span class="zcc-error">Failed to connect.</span><%}%>


### PR DESCRIPTION
Using `//zello.com/channel-listen-widget-support` as an URL to be redirected when support article is ready