### PR TITLE
Allow microphone to change while recording

### DIFF
--- a/sdks/js/src/classes/recorder.js
+++ b/sdks/js/src/classes/recorder.js
@@ -80,10 +80,10 @@ class Recorder {
     return this.audioContext;
   }
 
-  initAudioGraph(isInputDeviceChange = false) {
+  initAudioGraph(fromInputDeviceChange = false) {
 
     // First buffer can contain old data. Don't encode it.
-    if (!isInputDeviceChange) {
+    if (!fromInputDeviceChange) {
       this.encodeBuffers = () => {
         delete this.encodeBuffers;
       }; 
@@ -149,7 +149,7 @@ class Recorder {
   changeInputDevice() {
     if (this.state !== "recording") {
       return;
-    };
+    }
     this.options.mediaConstraints.audio = {deviceId: {exact: deviceId}};
     this.disconnectNodes();
     this.clearStream();

--- a/sdks/js/src/classes/recorder.js
+++ b/sdks/js/src/classes/recorder.js
@@ -80,7 +80,7 @@ class Recorder {
     return this.audioContext;
   }
 
-  initAudioGraph(isInputDeviceChange=false) {
+  initAudioGraph(isInputDeviceChange = false) {
 
     // First buffer can contain old data. Don't encode it.
     if (!isInputDeviceChange) {
@@ -147,18 +147,19 @@ class Recorder {
   }
 
   changeInputDevice() {
-    if (this.state = "recording") {
-      this.options.mediaConstraints.audio = {deviceId: {exact: deviceId}};
-      this.disconnectNodes();
-      this.clearStream();
-      this.initAudioContext();
-      this.initAudioGraph(true);
-      this.initSourceNode().then((sourceNode) => {
-        this.sourceNode = sourceNode;
-        this.sourceNode.connect(this.monitorGainNode);
-        this.sourceNode.connect(this.recordingGainNode);
-      });
-    }
+    if (this.state !== "recording") {
+      return;
+    };
+    this.options.mediaConstraints.audio = {deviceId: {exact: deviceId}};
+    this.disconnectNodes();
+    this.clearStream();
+    this.initAudioContext();
+    this.initAudioGraph(true);
+    this.initSourceNode().then((sourceNode) => {
+      this.sourceNode = sourceNode;
+      this.sourceNode.connect(this.monitorGainNode);
+      this.sourceNode.connect(this.recordingGainNode);
+    });
   }
 
   init() {

--- a/sdks/js/src/classes/recorder.js
+++ b/sdks/js/src/classes/recorder.js
@@ -146,7 +146,7 @@ class Recorder {
     }
   }
 
-  changeInputDevice() {
+  changeInputDevice(deviceId) {
     if (this.state !== "recording") {
       return;
     }


### PR DESCRIPTION
**Issue**
https://github.com/zelloptt/zello-desktop/issues/872

**Summary** 
We're making it so the user can change microphones while recording a message in `zello-desktop`. 

**Details**
Here is how recording works.
 
An audio context stores a graph data structure that connects source, processing, and destination nodes together. A source node inputs actual sound. In our case, it gets it from a stream from `getUserMedia()`. Processing nodes manipulate the sound (e.g. make it louder or distort it), and destination nodes tell the computer where to play the sound from (i.e. such-and-such speaker). In our case, we get a stream from the user's computer and pass it to the source node of an audio context. 

In this recorder, there is a processing node - the `scriptProcessorNode` - that has a callback function `onaudioprocess`. The sound is given to the callback in small chunks as an argument where it can be manipulated. In this code, instead of manipulating it, we actually pass the sound data to `encodeBuffers`, which, in `zello-desktop`, passes it to `ZCC.encoder` which takes the data and completes the process of sending the outgoing message. In short, `onaudioprocess` passes the data on. 

In order to change the input device, you have to change the stream/source. And as it happens, you can't change the stream/source of an audio context. That means that in order to change the input device, you have to create an entirely new audio context with new nodes. 

That's what `changeInputDevice ` does. It throws away the current stream and audio context and creates a new one using the stream of the preferred device. 
