### PR TITLE
Frame caching support

### DIFF
--- a/sdks/js/src/classes/outgoingMessage.js
+++ b/sdks/js/src/classes/outgoingMessage.js
@@ -46,16 +46,26 @@ class OutgoingMessage extends Emitter {
       return;
     }
     this.options.encoder.prototype.ondata = (data) => {
-      let packet = Utils.buildBinaryPacket(1, this.currentMessageId, ++this.currentPacketId, data);
-      /**
-       * Outgoing message packet encoded and ready to be sent to zello server. Session is following this event and sends data automatically
-       *
-       * @event OutgoingMessage#data_encoded
-       * @param {Uint8Array} packet encoded opus packet with headers
-       */
-      this.emit(Constants.EVENT_DATA_ENCODED, packet);
+      if (Array.isArray(data)) {
+        data.forEach((frame) =>
+          this.processEncodedData(frame)
+        );
+        return;
+      }
+      this.processEncodedData(data);
     };
     this.encoder = new this.options.encoder;
+  }
+
+  processEncodedData(data) {
+    let packet = Utils.buildBinaryPacket(1, this.currentMessageId, ++this.currentPacketId, data);
+    /**
+     * Outgoing message packet encoded and ready to be sent to zello server. Session is following this event and sends data automatically
+     *
+     * @event OutgoingMessage#data_encoded
+     * @param {Uint8Array} packet encoded opus packet with headers
+     */
+    this.emit(Constants.EVENT_DATA_ENCODED, packet);
   }
 
   initRecorder() {

--- a/sdks/js/src/classes/session.js
+++ b/sdks/js/src/classes/session.js
@@ -55,6 +55,7 @@ class Session extends Emitter {
     if (
       !initialOptions ||
       !initialOptions.serverUrl ||
+      !initialOptions.authToken ||
       !initialOptions.channel ||
       (initialOptions.username && !initialOptions.password)
     ) {

--- a/sdks/js/src/classes/session.js
+++ b/sdks/js/src/classes/session.js
@@ -55,7 +55,6 @@ class Session extends Emitter {
     if (
       !initialOptions ||
       !initialOptions.serverUrl ||
-      !initialOptions.authToken ||
       !initialOptions.channel ||
       (initialOptions.username && !initialOptions.password)
     ) {


### PR DESCRIPTION
Adds support for the cached frame performance enhancement in the encoder.  I have tested this via the 02-player-recorder example but did not see a significant difference; additional logging of the recorder/encoder config would be useful