### PR TITLE
Updates iOS SDK to 0.5.7 and removes auth token

### DIFF
--- a/sdks/ios/ZelloChannelDemo/Podfile
+++ b/sdks/ios/ZelloChannelDemo/Podfile
@@ -6,5 +6,5 @@ target 'ZelloChannelDemo' do
   use_frameworks!
 
   # Pods for ZelloChannelDemo
-  pod 'ZelloChannelKit', '~> 0.5.6'
+  pod 'ZelloChannelKit', '~> 0.5.7'
 end

--- a/sdks/ios/ZelloChannelDemo/Podfile.lock
+++ b/sdks/ios/ZelloChannelDemo/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
   - zello-opus-ios (1.0.1)
-  - ZelloChannelKit (0.5.6):
+  - ZelloChannelKit (0.5.7):
     - zello-opus-ios (~> 1.0.1)
-    - ZelloChannelKit/libopus (= 0.5.6)
-    - ZelloChannelKit/SocketRocket (= 0.5.6)
-  - ZelloChannelKit/libopus (0.5.6):
+    - ZelloChannelKit/libopus (= 0.5.7)
+    - ZelloChannelKit/SocketRocket (= 0.5.7)
+  - ZelloChannelKit/libopus (0.5.7):
     - zello-opus-ios (~> 1.0.1)
-  - ZelloChannelKit/SocketRocket (0.5.6):
+  - ZelloChannelKit/SocketRocket (0.5.7):
     - zello-opus-ios (~> 1.0.1)
 
 DEPENDENCIES:
-  - ZelloChannelKit (~> 0.5.6)
+  - ZelloChannelKit (~> 0.5.7)
 
 SPEC REPOS:
   trunk:
@@ -19,8 +19,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   zello-opus-ios: 8c1f08799d7a147c86f21ec2a18f7b19f8c2ceed
-  ZelloChannelKit: 14a74ad8722d388d5fdc5d78764feb1fad6355bc
+  ZelloChannelKit: 55b800a5c444fc0761909dda11fc0f85a4bf86ce
 
-PODFILE CHECKSUM: 75f63d167a6087a133cf8c20c9b255ea64e30d88
+PODFILE CHECKSUM: 7b4e1ececdbc8b52dac8b3ffabe053648856a90e
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.15.2

--- a/sdks/ios/ZelloChannelDemo/ZelloChannelDemo/App Delegate/Zello.m
+++ b/sdks/ios/ZelloChannelDemo/ZelloChannelDemo/App Delegate/Zello.m
@@ -8,8 +8,6 @@
 
 #import "Zello.h"
 
-static NSString * const developmentToken = @"[YOUR TOKEN HERE]";
-
 static ZCCSession *_session;
 
 @implementation Zello
@@ -19,7 +17,8 @@ static ZCCSession *_session;
 }
 
 + (void)setupSessionWithURL:(NSURL *)url channel:(NSString *)channel username:(NSString *)username password:(NSString *)password {
-  _session = [[ZCCSession alloc] initWithURL:url authToken:developmentToken username:username password:password channel:channel callbackQueue:nil];
+  // authToken is required for connecting to Friends & Family Zello, but should be nil for Zello Work
+  _session = [[ZCCSession alloc] initWithURL:url authToken:nil username:username password:password channel:channel callbackQueue:nil];
 }
 
 + (void)closeSession {


### PR DESCRIPTION
The iOS Channels SDK was updated in v0.5.7 to make the auth token optional. This commit updates the sample app to use version 0.5.7 of the SDK and removes the auth token from the session setup call.