### PR TITLE
Update auth documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -6,17 +6,17 @@ Version 1.0
 
 ## Overview
 
-This document is intended for developers interested in implementation of their own Zello Channel API client connecting to Zello channels. If you want integrate Zello into your iOS or Android app, check out the [mobile SDKs](sdks) instead.
+This document is intended for developers interested in implementation of their own Zello Channel API client connecting to Zello channels. If you want to integrate Zello into your iOS or Android app, check out the [Zello SDK](https://sdk.zello.com/) instead.
 
-This API supports subset of Zello features and currently focused on sending and receiving channel voice messages. See [Supported features](#supported-features) for the complete list.
+This API supports a subset of Zello features and is currently focused on sending and receiving channel voice messages. See [Supported features](#supported-features) for the complete list.
 
-To access the API you will need valid account credentials and/or a valid access token, based on the [JWT](https://jwt.io/) standard. See [Authentication](#authentication).
+To access the API you will need valid account credentials and (for Zello Friends & Family) a valid access token, based on the [JWT](https://jwt.io/) standard. See [Authentication](#authentication).
 
 ## API entry points
-| Service | WebSocket URL
-|---|---
-| Consumer Zello | wss://zello.io/ws
-| Zello Work | wss://zellowork.io/ws/`network name`
+| Service                 | WebSocket URL
+|-------------------------|---
+| Zello Friends & Family  | wss://zello.io/ws
+| Zello Work              | wss://zellowork.io/ws/`network name`
 | Zello Enterprise Server | wss://`your server domain`/ws/mesh
 
 Note that the protocol only supports secure connections over TLS.
@@ -29,15 +29,15 @@ Anonymous accounts:
 
 * No need to provide username or password
 * Can access unrestricted channels in listen only mode
-* Only supported with consumer Zello
-* A valid [auth token](AUTH.md) is required
+* Only supported with Zello Friends & Family
+* A valid [auth token](AUTH.md) is required for Zello Friends & Family
 
 Named accounts:
 
 * Must include a valid username and password
 * Have full access to authorized channels
-* Supported for both Zello Work and consumer Zello
-* A valid [auth token](AUTH.md) is required for consumer Zello
+* Supported for both Zello Work and Zello Friends & Family
+* A valid [auth token](AUTH.md) is required for Zello Friends & Family
 
 ## Connection keepalive
 The API monitors connectivity by sending a [WebSocket Ping frame](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2) to the client every 30 seconds. The WebSocket client must respond to the Ping frame with a Pong frame. If a client takes longer than 30 seconds to respond with a Pong frame, the API terminates the connection.
@@ -68,19 +68,48 @@ Connecting to multiple channels (up to 100) is currently supported for Zello Wor
 |-----------------|---|---
 | `command`       | string | `logon`
 | `seq`           | integer | Command sequence number
-| `auth_token`    | string | (optional) API authentication token. If omitted `refresh_token` is required when connecting to consumer Zello. See [Authentication](#authentication)
-| `refresh_token` | string | (optional) API refresh token. If omitted `auth_token ` is required when connecting to consumer Zello. See [Authentication](#authentication)
-| `username`      | string | (optional) Username to logon with. If not provided the client will connect anonymously. See [Authentication](#authentication)
-| `password`      | string | (optional) Password to logon with. Required if username is provided.
+| `auth_token`    | string | (Zello Friends & Family only) API authentication token. If omitted `refresh_token` is required. See [Authentication](#authentication).
+| `refresh_token` | string | (Zello Friends & Family only) API refresh token. If omitted `auth_token ` is required. See [Authentication](#authentication).
+| `username`      | string | (optional for Zello Friends & Family) Username to logon with. If not provided the client will connect anonymously. See [Authentication](#authentication)
+| `password`      | string | (optional for Zello Friends & Family) Password to logon with. Required if username is provided.
 | `channels`      | array of strings | The list of names of the channels to connect to. 
-| `listen_only`   | boolean | (optional) Set to `true` to connect in listen-only mode.
+| `listen_only`   | boolean | (optional for Zello Friends & Family) Set to `true` to connect in listen-only mode.
 | `version`       | string | (optional) Client version string. If not provided, the server will use the Channel API server version.
 | `platform_type` | string | (optional) Client platform type, any string
 | `platform_name` | string | (optional) Client platform name, any string. If includes `Gateway` or `Kiosk` (case-insensitive), the Zello Alarms service will track the online status of this client.
 | `language`      | string | (optional) Client ISO 639-1 language code. Required for translation channels.
 
-#### Request:
+### Zello Work
 
+#### Request:
+```json
+{
+  "command": "logon",
+  "seq": 1,
+  "username": "sherlock",
+  "password": "secret",
+  "channels": ["Baker Street 221B", "Reichenbach Falls"]
+}
+``` 
+#### Response:
+
+```json
+{
+  "seq": 1,
+  "success": true
+}
+```
+or
+
+```json
+{
+  "seq": 1,
+  "error": "error code"
+}
+```
+### Zello Friends & Family
+
+#### Request:
 ```json
 {
   "command": "logon",
@@ -583,14 +612,14 @@ Indicates incoming shared location from the channel.
 |Error Code | Description
 |---|---
 |unknown command | Server didn't recognize the command received from the client.
-|internal server error | An internal error occured within the server. If the error persists please contact us at support@zello.com
-|invalid json | The command received included malformed JSON
+|internal server error | An internal error occured within the server. If the error persists please contact us at support@zello.com.
+|invalid json | The command received included malformed JSON.
 |invalid request | The server couldn't recognize command format.
 |not authorized | Username, password or token are not valid.
 |not logged in | Server received a command before successful `logon`.
 |not enough params | The command doesn't include some of the required attributes.
-|server closed connection | The connection to Zello network was closed. You can try re-connecting.
-|channel is not ready | Channel you are trying to talk to is not yet connected. Wait for channel `online` status before sending a message
+|server closed connection | The connection to Zello network was closed. You can try reconnecting.
+|channel is not ready | Channel you are trying to talk to is not yet connected. Wait for channel `online` status before sending a message.
 |listen only connection | The client tried to send a message over listen-only connection.
 |failed to start stream | Unable to start the stream for unknown reason. You can try again later.
 |failed to stop stream | Unable to stop the stream for unknown reason. This error is safe to ignore.
@@ -602,14 +631,14 @@ Indicates incoming shared location from the channel.
 ## Supported features
 
 
-|Feature|Consumer Zello|Zello Work
-|---|---|---
-|Access channels using authorized user credentials | Supported | Supported
-|Access channels anonymously in listen only mode | Supported | Not supported
-|Send and receive voice messages | Supported | Supported
-|Interoperability with Zello apps on Android, iOS, and PC | Supported | Supported
-|Create and access ad hoc channels anonymously | Planned | Planned
-|Send and receive images | Supported | Supported
-|Send and receive text messages | Supported | Supported
-|Send and receive locations | Supported | Supported
-|Send and receive emergency alerts | - | Planned
+|Feature| Zello Friends & Family |Zello Work
+|---|------------------------|---
+|Access channels using authorized user credentials | Supported              | Supported
+|Access channels anonymously in listen only mode | Supported              | Not supported
+|Send and receive voice messages | Supported              | Supported
+|Interoperability with Zello apps on Android, iOS, and PC | Supported              | Supported
+|Create and access ad hoc channels anonymously | Planned                | Planned
+|Send and receive images | Supported              | Supported
+|Send and receive text messages | Supported              | Supported
+|Send and receive locations | Supported              | Supported
+|Send and receive emergency alerts | -                      | Planned

--- a/API.md
+++ b/API.md
@@ -10,12 +10,12 @@ This document is intended for developers interested in implementation of their o
 
 This API supports a subset of Zello features and is currently focused on sending and receiving channel voice messages. See [Supported features](#supported-features) for the complete list.
 
-To access the API you will need valid account credentials and (for Zello Friends & Family) a valid access token, based on the [JWT](https://jwt.io/) standard. See [Authentication](#authentication).
+To access the API you will need valid account credentials and (for Zello Friends and Family) a valid access token, based on the [JWT](https://jwt.io/) standard. See [Authentication](#authentication).
 
 ## API entry points
 | Service                 | WebSocket URL
 |-------------------------|---
-| Zello Friends & Family  | wss://zello.io/ws
+| Zello Friends and Family  | wss://zello.io/ws
 | Zello Work              | wss://zellowork.io/ws/`network name`
 | Zello Enterprise Server | wss://`your server domain`/ws/mesh
 
@@ -29,15 +29,15 @@ Anonymous accounts:
 
 * No need to provide username or password
 * Can access unrestricted channels in listen only mode
-* Only supported with Zello Friends & Family
-* A valid [auth token](AUTH.md) is required for Zello Friends & Family
+* Only supported with Zello Friends and Family
+* A valid [auth token](AUTH.md) is required for Zello Friends and Family
 
 Named accounts:
 
 * Must include a valid username and password
 * Have full access to authorized channels
-* Supported for both Zello Work and Zello Friends & Family
-* A valid [auth token](AUTH.md) is required for Zello Friends & Family
+* Supported for both Zello Work and Zello Friends and Family
+* A valid [auth token](AUTH.md) is required for Zello Friends and Family
 
 ## Connection keepalive
 The API monitors connectivity by sending a [WebSocket Ping frame](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2) to the client every 30 seconds. The WebSocket client must respond to the Ping frame with a Pong frame. If a client takes longer than 30 seconds to respond with a Pong frame, the API terminates the connection.
@@ -68,12 +68,12 @@ Connecting to multiple channels (up to 100) is currently supported for Zello Wor
 |-----------------|---|---
 | `command`       | string | `logon`
 | `seq`           | integer | Command sequence number
-| `auth_token`    | string | (Zello Friends & Family only) API authentication token. If omitted `refresh_token` is required. See [Authentication](#authentication).
-| `refresh_token` | string | (Zello Friends & Family only) API refresh token. If omitted `auth_token ` is required. See [Authentication](#authentication).
-| `username`      | string | (optional for Zello Friends & Family) Username to logon with. If not provided the client will connect anonymously. See [Authentication](#authentication)
-| `password`      | string | (optional for Zello Friends & Family) Password to logon with. Required if username is provided.
+| `auth_token`    | string | (Zello Friends and Family only) API authentication token. If omitted `refresh_token` is required. See [Authentication](#authentication).
+| `refresh_token` | string | (Zello Friends and Family only) API refresh token. If omitted `auth_token ` is required. See [Authentication](#authentication).
+| `username`      | string | (optional for Zello Friends and Family) Username to logon with. If not provided the client will connect anonymously. See [Authentication](#authentication).
+| `password`      | string | (optional for Zello Friends and Family) Password to logon with. Required if username is provided.
 | `channels`      | array of strings | The list of names of the channels to connect to. 
-| `listen_only`   | boolean | (optional for Zello Friends & Family) Set to `true` to connect in listen-only mode.
+| `listen_only`   | boolean | (optional; supported on Zello Friends and Family only) Set to `true` to connect in listen-only mode.
 | `version`       | string | (optional) Client version string. If not provided, the server will use the Channel API server version.
 | `platform_type` | string | (optional) Client platform type, any string
 | `platform_name` | string | (optional) Client platform name, any string. If includes `Gateway` or `Kiosk` (case-insensitive), the Zello Alarms service will track the online status of this client.
@@ -107,7 +107,7 @@ or
   "error": "error code"
 }
 ```
-### Zello Friends & Family
+### Zello Friends and Family
 
 #### Request:
 ```json
@@ -631,7 +631,7 @@ Indicates incoming shared location from the channel.
 ## Supported features
 
 
-|Feature| Zello Friends & Family |Zello Work
+|Feature| Zello Friends and Family |Zello Work
 |---|------------------------|---
 |Access channels using authorized user credentials | Supported              | Supported
 |Access channels anonymously in listen only mode | Supported              | Not supported

--- a/AUTH.md
+++ b/AUTH.md
@@ -5,7 +5,7 @@ To use the Channel API or SDK with Zello Friends and Family you'll need a valid 
 ## Generate API keys and development token
 
 1. Go to https://developers.zello.com/ and click __Login__
-2. Enter your Zello username and password. If you don't have a Zello account, [download the Zello app](https://zello.com/personal/download/) and create one.
+2. Enter your Zello username and password. If you don't have a Zello account, [download the Zello app](https://zello.com/downloads/) and create one.
 3. Complete all fields in the developer profile and click __Submit__
 4. Click __Keys__ and __Add Key__
 5. Copy and save __Sample Development Token__, __Issuer__, and __Private Key__. Make sure you copy each of the values completely using Select All.

--- a/AUTH.md
+++ b/AUTH.md
@@ -1,6 +1,6 @@
 # Zello Channel API auth tokens
 
-To use the Channel API or SDK with Zello Friends & Family you'll need a valid access token. This document describes how to get one.
+To use the Channel API or SDK with Zello Friends and Family you'll need a valid access token. This document describes how to get one.
 
 ## Generate API keys and development token
 

--- a/AUTH.md
+++ b/AUTH.md
@@ -1,11 +1,11 @@
 # Zello Channel API auth tokens
 
-To use the API or the SDK with Zello Consumer you'll need a valid access token. This document describes how to get one.
+To use the Channel API or SDK with Zello Friends & Family you'll need a valid access token. This document describes how to get one.
 
 ## Generate API keys and development token
 
 1. Go to https://developers.zello.com/ and click __Login__
-2. Enter your Zello username and password. If you don't have Zello account [download Zello app](https://zello.com/personal/download/) and create one.
+2. Enter your Zello username and password. If you don't have a Zello account, [download the Zello app](https://zello.com/personal/download/) and create one.
 3. Complete all fields in the developer profile and click __Submit__
 4. Click __Keys__ and __Add Key__
 5. Copy and save __Sample Development Token__, __Issuer__, and __Private Key__. Make sure you copy each of the values completely using Select All.
@@ -13,7 +13,7 @@ To use the API or the SDK with Zello Consumer you'll need a valid access token. 
 
 ## Using sample development token
 
-The developer token you received is valid for 30 days and can be used in your app to connect to the API making it easy to test without building your own server for provisioning the actual tokens. Pass the sample development token as `auth_token` when performing logon.
+The developer token you received is valid for 30 days and can be used in your app to connect to the API, making it easy to test without building your own server for provisioning the actual tokens. Pass the sample development token as `auth_token` when performing logon.
 
 If your development token expires repeat [the steps above](#generate-api-keys-and-development-token) to create a new one.
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -1,6 +1,6 @@
 ## Channel API Authentication
 
-> __Note__: The following applies only to the Zello Friends & Family platform. If you are using the Channel API with a 
+> __Note__: The following applies only to the Zello Friends and Family platform. If you are using the Channel API with a 
 Zello Work account, you should omit the `auth_token` property from your `logon` command.
 
 The Zello Channel API relies on the [JWT](https://jwt.io/introduction/) standard

--- a/auth/README.md
+++ b/auth/README.md
@@ -1,5 +1,8 @@
 ## Channel API Authentication
 
+> __Note__: The following applies only to the Zello Friends & Family platform. If you are using the Channel API with a 
+Zello Work account, you should omit the `auth_token` property from your `logon` command.
+
 The Zello Channel API relies on the [JWT](https://jwt.io/introduction/) standard
 to identify and validate connection requests.
 
@@ -19,16 +22,17 @@ and expiration.  For example:
 JWTs for the Zello Channel API use RSA encryption (`"typ": "RS256"`) and so must be signed by a private key.
 
 Both the issuer and the private key are available through the key management tools
-in the [developer portal](https://developers.zello.com).  If you are building a client
-for the ZelloWork Channel API, you can manage keys through your admin console.
+in the [developer portal](https://developers.zello.com).
 
 Because your private keys must remain private at all times, you should implement 
 token generation on the server side, passing newly created tokens only to your authorized
-clients, which in turn will pass them to the Zello channel API.
+clients, which in turn will pass them to the Zello Channel API.
 
-![auth flow](auth_flow.png)
+<div style="background-color: #ffffff;">
+  <img src="auth_flow.png" alt="auth flow" />
+</div>
 
-Once you have a token, pass it in the `auth_token` field of the Zello Channel API [logon](https://github.com/zelloptt/zello-channel-api/blob/master/API.md#logon-1) request
+Once you have a token, pass it in the `auth_token` field of the Zello Channel API [logon](https://github.com/zelloptt/zello-channel-api/blob/master/API.md#logon-1) request.
 
 We have included sample code demonstrating how to create JWTs in [PHP](php),
-[node JS](js), and [golang](go).
+[Node.js](js), and [Golang](go).


### PR DESCRIPTION
The support team receives a number of tickets from integrators that are having trouble authenticating with the Channel API. Specifically, the documenation says that the `auth_token` field is optional for Zello Work, when in reality there is no way for a customer to generate the necessary token.

These changes make it clear that `auth_token` applies only to F&F accounts, which in turn should reduce the number of support tickets generated for this topic.

I also made some small grammatical edits, updated old URLs, and changed references to Zello consumer to Zello Friends and Family ([context](https://zello.slack.com/archives/CC21AJA49/p1729609623908209)).