### PR TITLE
docs(js-sdk): point script tag examples at /latest/ CDN path

### DIFF
--- a/docs/js/Sdk.html
+++ b/docs/js/Sdk.html
@@ -116,14 +116,14 @@ and also return promises that resolve with <code>result</code> argument or fail 
     <h5>Example</h5>
     
     <pre class="prettyprint"><code>&lt;!-- Load sdk using &lt;script> tag: -->
-&lt;script src="https://zello.io/sdks/js/0.1/zcc.sdk.js">&lt;/script>
+&lt;script src="https://zello.io/sdks/js/latest/zcc.sdk.js">&lt;/script>
 &lt;script>
   console.log(ZCC);
 &lt;/script>
 
 &lt;!-- Load sdk using async script loader (e.g. scriptjs) -->
 &lt;script>
-$script(['https://zello.io/sdks/js/0.1/zcc.sdk.js'], function() {
+$script(['https://zello.io/sdks/js/latest/zcc.sdk.js'], function() {
  console.log(ZCC);
 });
 &lt;/script></code></pre>

--- a/docs/js/sdk.js.html
+++ b/docs/js/sdk.js.html
@@ -40,14 +40,14 @@ let myUrl = null;
  *
  * @example
  * &lt;!-- Load sdk using &lt;script> tag: -->
- * &lt;script src="https://zello.io/sdks/js/0.1/zcc.sdk.js">&lt;/script>
+ * &lt;script src="https://zello.io/sdks/js/latest/zcc.sdk.js">&lt;/script>
  * &lt;script>
  *   console.log(ZCC);
  * &lt;/script>
  *
  * &lt;!-- Load sdk using async script loader (e.g. scriptjs) -->
  * &lt;script>
- * $script(['https://zello.io/sdks/js/0.1/zcc.sdk.js'], function() {
+ * $script(['https://zello.io/sdks/js/latest/zcc.sdk.js'], function() {
  *  console.log(ZCC);
  * });
  * &lt;/script>

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -79,7 +79,7 @@ Load SDK and then call `ZCC.Sdk.init` method with optional parameters to disable
 
 ```html
 <!-- Load sdk using <script> tag: -->
-<script src="https://zello.io/sdks/js/0.1/zcc.sdk.js"></script>
+<script src="https://zello.io/sdks/js/latest/zcc.sdk.js"></script>
 <script>
     // callback style
     ZCC.Sdk.init({
@@ -101,7 +101,7 @@ Load SDK and then call `ZCC.Sdk.init` method with optional parameters to disable
     Once SDK is loaded, call .init method
 -->
 <script>
-$script(['https://zello.io/sdks/js/0.1/zcc.sdk.js'], function() {
+$script(['https://zello.io/sdks/js/latest/zcc.sdk.js'], function() {
     // promise style
     ZCC.Sdk.init({
       player: true,

--- a/sdks/js/src/classes/sdk.js
+++ b/sdks/js/src/classes/sdk.js
@@ -12,14 +12,14 @@ let myUrl = null;
  *
  * @example
  * <!-- Load sdk using <script> tag: -->
- * <script src="https://zello.io/sdks/js/0.1/zcc.sdk.js"></script>
+ * <script src="https://zello.io/sdks/js/latest/zcc.sdk.js"></script>
  * <script>
  *   console.log(ZCC);
  * </script>
  *
  * <!-- Load sdk using async script loader (e.g. scriptjs) -->
  * <script>
- * $script(['https://zello.io/sdks/js/0.1/zcc.sdk.js'], function() {
+ * $script(['https://zello.io/sdks/js/latest/zcc.sdk.js'], function() {
  *  console.log(ZCC);
  * });
  * </script>


### PR DESCRIPTION
## Summary
- Update `zello.io/sdks/js/0.1/zcc.sdk.js` references to `zello.io/sdks/js/latest/zcc.sdk.js` so embed examples track the current SDK release instead of a pinned 0.1 build.
- Touches the JSDoc source (`sdks/js/src/classes/sdk.js`), the SDK README, and the two generated JSDoc HTML files under `docs/js/`.

## Test plan
- [ ] Confirm `https://zello.io/sdks/js/latest/zcc.sdk.js` resolves to the expected current build.
- [ ] Spot-check rendered JSDoc / README so the script tag examples show the `/latest/` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)